### PR TITLE
Added vidcount command

### DIFF
--- a/lib/chatcommands.js
+++ b/lib/chatcommands.js
@@ -2476,6 +2476,48 @@ function createCommands(bot) {
             return false;
         }
       });
+    }),
+    "vidcount": new Command({
+      cmdName: "vidcount",
+      minRank: bot.RANKS.user,
+      rankMatch: ">=",
+      userCooldown: 10000,
+      cmdCooldown: 5000,
+      isActive: true,
+      requiredChannelPerms: ["chat"],
+      allowRangeChange: true,
+      canBeUsedInPM: true
+    }, function(cmd, user, message, opts){
+      if(message.trim() !== ""){
+        const usernameArg = message.split("")[0];
+        const playlist = bot.CHANNEL.playlist;
+        let vidCount = 0;
+        let username = null;
+
+        if(usernameArg){
+          if(utils.isValidUserName(usernameArg)) {
+            username = usernameArg.toLowerCase();
+          } else {
+            bot.sendPM(`${usernameArg} is an invalid username`)
+            return false;
+          }
+        } else {
+          username = user.name.toLowerCase()
+        }
+
+        for(let i = 0; i < playlist.length; i++){
+          const playlistItem = playlist[i];
+
+          if(playlistItem.queueby.toLowerCase() === username){
+            vidCount++;
+          }
+        }
+
+        bot.sendPM(strings.format(bot, "CHAT_VIDCOUNT", [(usernameArg ? `${usernameArg} has` : 'You have'), vidCount, (vidCount === 1 ? 'video' : 'videos' )]));
+        return true;
+      }
+
+      return false;
     })
   }
 

--- a/lib/strings.js
+++ b/lib/strings.js
@@ -48,6 +48,7 @@ var strings = {
   CHAT_UEC_NONEUSED: "<UserEC> %s0 has not used any emotes.",
   CHAT_UEC_NOTUSED: "<UserEC> %s0 has not used %s1 before.",
   CHAT_UPTIME: "Uptime: %s0",
+  CHAT_VIDCOUNT: "%s0 %s1 %s2 in the playlist.",
   CLI_INPUT: "[CLI] %s0",
   CLI_NOT_ACCEPTING_INPUT:"Bot is not yet accepting CLI input, please wait",
   CLI_ACCEPTING_INPUT:"Now accepting CLI input",


### PR DESCRIPTION
Allows users and mods to check the total video count they have in the playlist. The command can be used by itself or with a username argument.

Syntax: `$vidcount <username?>`

Developed solely based on assessing the existing codebase and its syntax so might not all be there. Not sure of the best way to go about testing it.